### PR TITLE
0.6.1-a version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.6.1-a - 2024-10-29
+### Changed
+- updated `EVAA_LP_MAINNET_VERSION` to `3`
+- `awaitedSupply` is always defined
+### Fixed
+- `applyDust` is `false` by default in `parseUserLiteData` and `parseUserData`
+- `minimalOracles` is `3` in all pools
+
+
 ## 0.6.1 - 2024-10-22
 ### Changed
 - added liquidation.ts with ```findAssetById```, ```calculateAssetsValues```, ```selectGreatestAssets```, ```calculateMinCollateralByTransferredAmount```, ```calculateLiquidationAmounts```, ```isLiquidatable```, ```isBadDebt```, ```addReserve```, ```deductReserve```, ```toAssetAmount```, ```toAssetWorth```, ```addLiquidationBonus```, ```deductLiquidationBonus```, ```PreparedAssetInfo```, ```prepareAssetInfo``` functions required or flexible liquidations calculation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@evaafi/sdkv6",
-  "version": "0.0.2",
+  "version": "0.6.1-a",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@evaafi/sdkv6",
-      "version": "0.0.2",
+      "version": "0.6.1-a",
       "license": "MIT",
       "dependencies": {
         "@ton/ton": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evaafi/sdk",
-  "version": "0.6.1",
+  "version": "0.6.1-a",
   "description": "The EVAA SDK is designed to easily integrate with the EVAA lending protocol on TON blockchain.",
   "main": "dist/index.js",
   "files": [

--- a/src/api/parser.ts
+++ b/src/api/parser.ts
@@ -205,7 +205,7 @@ export function parseUserLiteData(
     assetsData: ExtendedAssetsData,
     assetsConfig: ExtendedAssetsConfig,
     poolConfig: PoolConfig,
-    applyDust: boolean = true
+    applyDust: boolean = false
 ): UserLiteData {
     const poolAssetsConfig = poolConfig.poolAssetsConfig;
     const masterConstants = poolConfig.masterConstants;
@@ -283,7 +283,7 @@ export function parseUserData(
     assetsConfig: ExtendedAssetsConfig,
     prices: Dictionary<bigint, bigint>,
     poolConfig: PoolConfig,
-    applyDust: boolean = true
+    applyDust: boolean = false
 ): UserData {
     const poolAssetsConfig = poolConfig.poolAssetsConfig;
     const masterConstants = poolConfig.masterConstants;

--- a/src/api/parser.ts
+++ b/src/api/parser.ts
@@ -40,9 +40,7 @@ export function createAssetData(): DictionaryValue<AssetData> {
             buidler.storeUint(src.balance, 64);
             buidler.storeUint(src.trackingSupplyIndex, 64);
             buidler.storeUint(src.trackingBorrowIndex, 64);
-            if (src.awaitedSupply) {
-                buidler.storeUint(src.awaitedSupply, 64);
-            }
+            buidler.storeUint(src.awaitedSupply, 64);
         },
         parse: (src: Slice) => {
             const sRate = BigInt(src.loadInt(64));
@@ -53,10 +51,7 @@ export function createAssetData(): DictionaryValue<AssetData> {
             const balance = BigInt(src.loadInt(64));
             const trackingSupplyIndex = BigInt(src.loadUint(64));
             const trackingBorrowIndex = BigInt(src.loadUint(64));
-            let awaitedSupply: bigint | undefined = undefined;
-            if (src.remainingBits == 64) {
-                awaitedSupply = BigInt(src.loadUint(64));   
-            }
+            const awaitedSupply = BigInt(src.loadUint(64));  
 
             return { sRate, bRate, totalSupply, totalBorrow, lastAccural, balance, trackingSupplyIndex, trackingBorrowIndex, awaitedSupply};
         },

--- a/src/constants/general.ts
+++ b/src/constants/general.ts
@@ -37,13 +37,10 @@ export const ORACLES_MAINNET: OracleNFT[] = [
 ];
 
 export const ORACLES_TESTNET: OracleNFT[] = [
-    {id: 0, address: '0x3bb147a37b7a7f874c39320440f352bddd2c9337e31a778731910f0266391650'}, 
-    {id: 1, address: '0x676767e93b05a21aec9023a65f73cffe1c725709c3c964a7c3f0fd4229089bfe'},
-    {id: 2, address: '0x9c9e65951b0c5920c286bdb3410babcaf21f85bc9c90c13172988630f1244e0f'},
-    {id: 3, address: '0x9dcf880229bfb68d7344fd294624b64f1e0b43b9d858f0fdb1bc6434616c08f5'},
-    {id: 4, address: '0x4d1afcf7c0426ca61c405c8cfaef0053a0f0d143740ffed04c8716beb99cd614'},
-    {id: 5, address: '0x11c6baa608ed10733051fd74134441d384e471722fbc496b43ea4e3c6652485f'},
-    {id: 6, address: '0x2b685672f38dc2fce59013bb740bf24c6037049a1c267bb3b5f6f55d5b195f5f'},
+    {id: 0, address: '0xd3a8c0b9fd44fd25a49289c631e3ac45689281f2f8cf0744400b4c65bed38e5d'}, 
+    {id: 1, address: '0x2c21cabdaa89739de16bde7bc44e86401fac334a3c7e55305fe5e7563043e191'},
+    {id: 2, address: '0x2eb258ce7b5d02466ab8a178ad8b0ba6ffa7b58ef21de3dc3b6dd359a1e16af0'},
+    {id: 3, address: '0xf9a0769954b4430bca95149fb3d876deb7799d8f74852e0ad4ccc5778ce68b52'},
 ];
 
 export const ORACLES_LP: OracleNFT[] = [

--- a/src/constants/general.ts
+++ b/src/constants/general.ts
@@ -27,7 +27,7 @@ export const MAINNET_VERSION = 6;
 export const EVAA_MASTER_TESTNET = Address.parse('EQDLsg3w-iBj26Gww7neYoJAxiT2t77Zo8ro56b0yuHsPp3C');
 export const TESTNET_VERSION = 0;
 export const EVAA_LP_MAINNET = Address.parse('EQBIlZX2URWkXCSg3QF2MJZU-wC5XkBoLww-hdWk2G37Jc6N');
-export const EVAA_LP_MAINNET_VERSION = 2;
+export const EVAA_LP_MAINNET_VERSION = 3;
 
 export const ORACLES_MAINNET: OracleNFT[] = [
     {id: 0, address: '0xd3a8c0b9fd44fd25a49289c631e3ac45689281f2f8cf0744400b4c65bed38e5d'}, 

--- a/src/constants/pools.ts
+++ b/src/constants/pools.ts
@@ -25,7 +25,7 @@ export const TESTNET_POOL_CONFIG: PoolConfig = {
     masterVersion: TESTNET_VERSION,
     masterConstants: MASTER_CONSTANTS,
     oracles: ORACLES_TESTNET,
-    minimalOracles: 5,
+    minimalOracles: 3,
     poolAssetsConfig: [
         TON_MAINNET,
         JUSDT_TESTNET,

--- a/src/types/Master.ts
+++ b/src/types/Master.ts
@@ -89,7 +89,7 @@ export type AssetData = {
     balance: bigint;
     trackingSupplyIndex: bigint;
     trackingBorrowIndex: bigint;
-    awaitedSupply?: bigint;
+    awaitedSupply: bigint;
 };
 
 export type AssetInterest = {


### PR DESCRIPTION
## 0.6.1-a - 2024-10-29
### Changed
- updated `EVAA_LP_MAINNET_VERSION` to `3`
- `awaitedSupply` is always defined
### Fixed
- `applyDust` is `false` by default in `parseUserLiteData` and `parseUserData`
- `minimalOracles` is `3` in all pools
